### PR TITLE
Captcha 0.2 was released

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -39,10 +39,10 @@ Jinja2 provides templating, and SQLAlchemy is used for the databases::
 
     dnf install python-cherrypy python-jinja2 python-sqlalchemy
 
-Here, we switch to using pip. We install captcha from github, because we rely
-on features not present in the Pypi repository. Eventually, we won't need this::
+Here, we switch to using pip. We install captcha from PyPI. We need at least
+version 0.2 of the captcha package::
 
-    pip install git+https://github.com/dperny/captcha.git
+    pip install captcha >= 0.2
 
 Finally, the portal itself::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Pillow
 cherrypy
 jinja2
 sqlalchemy
-git+https://github.com/dperny/captcha.git
+captcha >= 0.2
 

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,19 @@ from glob import glob
 
 DATA = 'share/freeipa_community_portal/'
 
+with open('requirements.txt') as f:
+    requirements = [
+        line.strip() for line in f
+        if line.strip() and not line.startswith('#')
+    ]
+
+with open('README') as f:
+    long_description = f.read()
+
 setup(name='freeipa_community_portal',
       version='0.2',
       description='A web application for FreeIPA in a community setting',
+      long_description=long_description,
       author='Drew Erny',
       author_email='derny@redhat.com',
       license='GPLv3',
@@ -54,5 +64,6 @@ setup(name='freeipa_community_portal',
           'install/freeipa-portal-install',
           'install/create-portal-user'
       ],
-      zip_safe=False
+      zip_safe=False,
+      install_requires=requirements,
       )


### PR DESCRIPTION
A new version of captcha was released today. The git checkout is no
longer needed.

Also specify requirements in setup.py

Signed-off-by: Christian Heimes <cheimes@redhat.com>