### PR TITLE
Issue12 client keytab

### DIFF
--- a/conf/freeipa_community_portal.ini
+++ b/conf/freeipa_community_portal.ini
@@ -27,3 +27,9 @@ key_location=/var/lib/freeipa_community_portal/key
 [Database]
 # the directory where we store our databases
 db_directory=/var/lib/freeipa_community_portal/
+
+[KRB5]
+# set KRB5_CLIENT_KTNAME if non-empty
+client_keytab=/etc/ipa/portal.keytab
+# set KRB5CCNAME if non-empty
+ccache_name=

--- a/conf/freeipa_community_portal_dev.ini
+++ b/conf/freeipa_community_portal_dev.ini
@@ -28,3 +28,8 @@ key_location=key
 # the directory where we store our databases
 db_directory=
 
+[KRB5]
+# set KRB5_CLIENT_KTNAME if non-empty
+client_keytab=portal.keytab
+# set KRB5CCNAME if non-empty
+ccache_name=

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -132,13 +132,20 @@ add a user called "portal" with the requisite permissions.
 The second thing needed is a way to authenticate via Kerberos as the user 
 created in the previous step. Specifically, we need to authenticate as a user 
 principal, and not a service principal. There's no canonical solution for this 
-yet, but what should work is creating a keytab for the portal user, and then 
-setting up cron to run k5start on reboot to keep the portal authenticated while 
-the server is up. When testing deployment, I tend to do something like:: 
+yet. A keytab for the portal user is an easy way to automatically authenticate
+the portal user. A client keytab for the portal can be acquired with
+``ipa-getkeytab``. You must properly secure the keytab, so it can only be
+read by the webserver::
 
-    su -s /bin/sh apache -c 'kinit portal'
+    ipa-getkeytab -s IPA_SERVER_HOSTNAME -p portal@YOUR.REALM -k /etc/ipa/portal.keytab
+    chown apache:apache /etc/ipa/portal.keytab
+    chmod 640 /etc/ipa/portal.keytab
 
-but this method requires manual intervention. 
+If you don't remember the values for IPA server and realm, have a look at
+``/etc/ipa/default.conf``. You can set the path to keytab in
+``/etc/freeipa_community_portal.ini``. The app sets the environment variable
+``KRB5_CLIENT_KTNAME``, when the value is not empty. ipalib picks the keytab
+up automatically.
 
 After all this, you should probably set up and configure mod_ssl and put the 
 app behind HTTPS, but that is outside of the scope of this guide. 

--- a/freeipa_community_portal/config.py
+++ b/freeipa_community_portal/config.py
@@ -1,0 +1,92 @@
+# Authors:
+#   Christian Heimes <cheimes@redhat.com>
+#
+# Copyright (C) 2015  Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import ConfigParser
+import os
+
+
+class Config(object):
+    default_configs = [
+        '/etc/freeipa_community_portal.ini',
+        'conf/freeipa_community_portal_dev.ini'
+    ]
+
+    captcha_length = 4
+
+    def __init__(self, *configs):
+        if not configs:
+            configs = self.default_configs
+        self._cfg = ConfigParser.SafeConfigParser()
+        print configs
+        self._cfg.read(configs)
+        self._captcha_key = None
+
+    @property
+    def captcha_db(self):
+        return os.path.join(self._cfg.get('Database', 'db_directory'),
+                            'captcha.db')
+
+    @property
+    def captcha_key_location(self):
+        return self._cfg.get('Captcha', 'key_location')
+
+    @property
+    def captcha_key(self):
+        if self._captcha_key is None:
+            with open(self.captcha_key_location, 'rb') as f:
+                self._captcha_key = f.read()
+        return self._captcha_key
+
+    @property
+    def reset_db(self):
+        return os.path.join(self._cfg.get('Database', 'db_directory'),
+                            'resets.db')
+
+    @property
+    def smtp_server(self):
+        return self._cfg.get('Mailers', 'smtp_server')
+
+    @property
+    def smtp_port(self):
+        return self._cfg.getint('Mailers', 'smtp_port')
+
+    @property
+    def smtp_security_type(self):
+        return self._cfg.get('Mailers', 'smtp_security_type')
+
+    @property
+    def smtp_auth(self):
+        if self._cfg.getboolean('Mailers', 'smtp_use_auth'):
+            return (
+                self._cfg.get('Mailers', 'smtp_username'),
+                self._cfg.get('Mailers', 'smtp_password')
+            )
+        else:
+            return None
+
+    @property
+    def default_admin_email(self):
+        return self._cfg.get('Mailers', 'default_admin_email')
+
+    @property
+    def default_from_email(self):
+        return self._cfg.get('Mailers', 'default_from_email')
+
+
+config = Config()

--- a/freeipa_community_portal/config.py
+++ b/freeipa_community_portal/config.py
@@ -37,6 +37,13 @@ class Config(object):
         self._cfg.read(configs)
         self._captcha_key = None
 
+    def _get_default(self, section, option, raw=False, vars=None,
+                     default=None):
+        try:
+            return self._cfg.get(section, option, raw=raw, vars=vars)
+        except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+            return default
+
     @property
     def captcha_db(self):
         return os.path.join(self._cfg.get('Database', 'db_directory'),
@@ -87,6 +94,20 @@ class Config(object):
     @property
     def default_from_email(self):
         return self._cfg.get('Mailers', 'default_from_email')
+
+    @property
+    def client_keytab(self):
+        keytab = self._get_default('KRB5', 'client_keytab')
+        if not keytab or not keytab.strip():
+            return None
+        return keytab
+
+    @property
+    def ccache_name(self):
+        ccache_name = self._get_default('KRB5', 'client_keytab')
+        if not ccache_name or not ccache_name.strip():
+            return None
+        return ccache_name
 
 
 config = Config()

--- a/freeipa_community_portal/model/__init__.py
+++ b/freeipa_community_portal/model/__init__.py
@@ -23,14 +23,25 @@ This module contains all of the models for the community portal.
 Models in this app are backed by and interact with the freeipa server using
 ipalib. they should be the sole holders of the ipalib dependency
 """
+import os
+
 from ipalib import api
 
+from ..config import config
 
 def api_connect():
     """Initialize and connect to FreeIPA's RPC server.
     """
     # delay initialization of API for pre-forking web servers
     if not api.isdone('bootstrap'):
+        # set client keytab env var for authentication
+        keytab = config.client_keytab
+        if keytab is not None:
+            os.environ['KRB5_CLIENT_KTNAME'] = keytab
+        ccname = config.ccache_name
+        if ccname is not None:
+            os.environ['KRB5CCNAME'] = ccname
+
         api.bootstrap(context='cli')
         api.finalize()
 

--- a/freeipa_community_portal/model/captcha_wrapper.py
+++ b/freeipa_community_portal/model/captcha_wrapper.py
@@ -26,37 +26,25 @@ import string
 import random
 import base64
 import hmac
-import os
 
 from sqlalchemy import Table, Column, MetaData, String, DateTime, create_engine
 from sqlalchemy.sql import select, insert, delete
 
-import ConfigParser
-
-Config = ConfigParser.ConfigParser()
-Config.read(['/etc/freeipa_community_portal.ini', 'conf/freeipa_community_portal_dev.ini'])
-
-KEY_LOCATION = Config.get('Captcha','key_location')
-DATABASE_LOCATION = Config.get('Database', 'db_directory') + 'captcha.db'
-
-print DATABASE_LOCATION
+from ..config import config
 
 # retrieve the captcha key from the key file
 # trust me, i know cryptography
-def getKey():
-    with open(KEY_LOCATION) as fp:
-        return fp.read()
+LENGTH = config.captcha_length
+KEY = config.captcha_key
 
-LENGTH = 4
-KEY = getKey()
-
-_engine = create_engine('sqlite:///' + DATABASE_LOCATION)
+_engine = create_engine('sqlite:///' + config.captcha_db)
 _metadata = MetaData()
 _captcha = Table('captcha', _metadata,
     Column('hmac', String, primary_key=True),
     Column('timestamp', DateTime)
 )
 _metadata.create_all(_engine)
+
 
 class CaptchaHelper(object):
     """Class for making a captcha for the client to display."""
@@ -79,7 +67,6 @@ class CaptchaHelper(object):
             )
         )
         conn.close()
-            
 
     def datauri(self):
         """Returns the captcha image to a data-uri, in jpeg format"""

--- a/freeipa_community_portal/model/password_reset.py
+++ b/freeipa_community_portal/model/password_reset.py
@@ -24,19 +24,13 @@ import base64
 from sqlalchemy import Table, Column, MetaData, String, DateTime, create_engine
 from sqlalchemy.sql import select, insert, delete
 
-import ConfigParser
-
 from ipalib import api, errors
 
 from . import api_connect
+from ..config import config
 
 
-Config = ConfigParser.ConfigParser()
-Config.read(['/etc/freeipa_community_portal.ini', 'conf/freeipa_community_portal_dev.ini'])
-
-DATABASE_LOCATION = Config.get('Database', 'db_directory') + 'resets.db'
-
-_engine = create_engine('sqlite:///' + DATABASE_LOCATION)
+_engine = create_engine('sqlite:///' + config.reset_db)
 
 _metadata = MetaData()
 _password_reset = Table('password_reset', _metadata,
@@ -145,4 +139,3 @@ class PasswordReset(object):
             delete(_password_reset).where(_password_reset.c.username == username)
         )
         conn.close()
-    


### PR DESCRIPTION
Add option to set KRB5_CLIENT_KTNAME and KRB5CCNAME

In order to simplify GSSAPI authentication for ipalib RPC, it is now
possible to set KRB5_CLIENT_KTNAME env var from the portal's config
file. The client keytab is then automatically used to authenticate
remote prodecure calls.

Depends on PR #16
Closes #12

Signed-off-by: Christian Heimes <cheimes@redhat.com>