### PR TITLE
Drop captcha key_location and auto-create key file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,4 @@ __pycache__
 
 # testing infrastrucutre
 /.tox
-/resets.db
-/captcha.db
-/key
+/var

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -35,7 +35,7 @@ The CAPTCHA functionality relies on the Pillow library::
     dnf install python-pillow
 
 These components are the core application. CherryPy as the web framework, 
-Jinja2 provides templating, and SQLAlchemy is used for the databases::
+Jinja2 provides templating, and SQLAlchemy is used for the database::
 
     dnf install python-cherrypy python-jinja2 python-sqlalchemy
 
@@ -83,13 +83,13 @@ Next, the installer copies the apache config from the conf directory to
 installation of the portal, you probably will not need this file, because you
 probably know what you're doing.
 
-Then, the installer creates the directory where the portal keeps its databases::
+Then, the installer creates the directory where the portal keeps its database::
 
     mkdir -p -m 750 /var/lib/freeipa_community_portal
     chown apache:apache /var/lib/freeipa_community_portal/
 
 If Apache doesn't own this folder, it will vomit when attempting to put 
-databases in it. Next, the installer generates a random key and stores it in a 
+database in it. Next, the installer generates a random key and stores it in a
 file called "captcha.key" the above directory. The portal uses this key to
 secure the captcha. It would be mostly harmless if this key gets compromised,
 so there's no need to take any special precautions to secure it.

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -85,14 +85,14 @@ probably know what you're doing.
 
 Then, the installer creates the directory where the portal keeps its databases::
 
-    mkdir -p  /var/lib/freeipa_community_portal
+    mkdir -p -m 750 /var/lib/freeipa_community_portal
     chown apache:apache /var/lib/freeipa_community_portal/
 
 If Apache doesn't own this folder, it will vomit when attempting to put 
 databases in it. Next, the installer generates a random key and stores it in a 
-file called "key" the above directory. The portal uses this key to secure the 
-captcha. It would be mostly harmless if this key gets compromised, so there's 
-no need to take any special precautions to secure it.
+file called "captcha.key" the above directory. The portal uses this key to
+secure the captcha. It would be mostly harmless if this key gets compromised,
+so there's no need to take any special precautions to secure it.
 
 After this, the installer does::
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -10,30 +10,21 @@ and then do::
 in the root of the tree. This should install a local, editable copy of the app,
 and put all of the configuration files and assets where they are expected.
 
-You will also have to create a key file for the captcha. Because this is 
-development, you can probably just do::
-
-    touch key
-
-and the empty file will work. There just needs to be a key file available to
-read.
-
 You can configure exactly where the application spews its files by editing the
-freeipa_community_portal_dev.ini file and plugging in values that make you 
-happy.
+freeipa_community_portal_dev.ini file in freeipa_community_portal/conf and
+plugging in values that make you happy. By default the development server uses
+var/ in your current working directory to store its database and captcha key
+file. The directory, sqlite database and key files are created automatically.
 
 Before you run the app, even in tree, you should kinit as a user with 
-sufficient permissions as outlined in the deployment doc.
+sufficient permissions as outlined in the deployment doc. You can also drop
+a client keytab in your var/ directory.
 
 To run the application in-tree, do::
 
-    python freeipa_community_portal/app.py
+    python -m freeipa_community_portal
 
-If you're running an IPA server on the host you're doing development on, one of
-the IPA apps already uses port 8080 (the default CherryPy port). You may need
-to add::
-
-    cherrypy.config.update({"server.socket_port": 8099})
-
-to app.py between lines 182 and 183. You can use any port that isn't being 
-used be default, not just 8099.
+On an IPA server Dogtag PKI is already occupying port 8080. For that reason
+the development server listens on port 10080 on localhost. You can change
+the port in freeipa_community_port/__main__.py if the port is already used
+on your machine.

--- a/freeipa_community_portal/__main__.py
+++ b/freeipa_community_portal/__main__.py
@@ -1,0 +1,43 @@
+# Authors:
+#   Christian Heimes <cheimes@redhat.com>
+#
+# Copyright (C) 2015  Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Entry point for development server
+
+Copy your keytab to ./var/portal.keytab and run::
+
+    python2.7 -m freeipa_community_portal
+
+"""
+import cherrypy
+
+from freeipa_community_portal import app
+from freeipa_community_portal.config import config
+
+config.load(config.development_config)
+
+# 8080 is occupied by Dogtag
+cherrypy.config.update({
+    'server.socket_host': '127.0.0.1',
+    'server.socket_port': 10080,
+})
+
+cherrypy.quickstart(
+    app.app(),
+    '/',
+    app.conf
+)

--- a/freeipa_community_portal/app.py
+++ b/freeipa_community_portal/app.py
@@ -33,6 +33,7 @@ from freeipa_community_portal.model.user import User
 from freeipa_community_portal.model.password_reset import PasswordReset
 # TODO: move over to a "from" import
 import freeipa_community_portal.model.captcha_wrapper as captcha_helper
+from freeipa_community_portal.config import config
 
 TEMPLATE_ENV = jinja2.Environment(loader=jinja2.PackageLoader('freeipa_community_portal','templates'))
 
@@ -149,6 +150,8 @@ def check_captcha(args):
         return "Incorrect Captcha response"
     else:
         return None
+
+
 conf = {
     '/assets':  {
         'tools.staticdir.on': True,
@@ -169,17 +172,16 @@ conf = {
     }
 }
 
+
 def app():
     """Main entry point for the web application. If you run this library as a
     standalone application, you can just use this function
     """
+    if not config:
+        raise ValueError('Run config.load(configfile) first!')
 
     webapp = SelfServicePortal()
-    webapp.user = SelfServiceUserRegistration() # pylint: disable=attribute-defined-outside-init
+    webapp.user = SelfServiceUserRegistration()  # pylint: disable=attribute-defined-outside-init
     webapp.request_reset = RequestSelfServicePasswordReset()
     webapp.reset_password = SelfServicePasswordReset()
     return webapp
-
-if __name__ == "__main__":
-    webapp = app()
-    cherrypy.quickstart(webapp, '/', conf)

--- a/freeipa_community_portal/conf/freeipa_community_portal.ini
+++ b/freeipa_community_portal/conf/freeipa_community_portal.ini
@@ -20,10 +20,6 @@ default_from_email=CHANGEME@example.com
 # the address to send admin mail to
 default_admin_email=CHANGEME@example.com
 
-[Captcha]
-# the location of the key
-key_location=/var/lib/freeipa_community_portal/key
-
 [Database]
 # the directory where we store our databases
 db_directory=/var/lib/freeipa_community_portal/

--- a/freeipa_community_portal/conf/freeipa_community_portal_dev.ini
+++ b/freeipa_community_portal/conf/freeipa_community_portal_dev.ini
@@ -18,18 +18,12 @@ default_from_email=user@example.com
 # the address to send admin mail to
 default_admin_email=user@example.com
 
-[Captcha]
-
-# the location of the key
-key_location=key
-
 [Database]
-
 # the directory where we store our databases
-db_directory=
+db_directory=var/
 
 [KRB5]
 # set KRB5_CLIENT_KTNAME if non-empty
-client_keytab=portal.keytab
+client_keytab=var/portal.keytab
 # set KRB5CCNAME if non-empty
 ccache_name=

--- a/freeipa_community_portal/freeipa_community_portal.wsgi
+++ b/freeipa_community_portal/freeipa_community_portal.wsgi
@@ -2,5 +2,12 @@
 
 import cherrypy
 from freeipa_community_portal import app
+from freeipa_community_portal.config import config
 
-application = cherrypy.Application(app.app(), script_name=None, config=app.conf)
+config.load(config.deployment_config)
+
+application = cherrypy.Application(
+    app.app(),
+    script_name=None,
+    config=app.conf
+)

--- a/install/freeipa-portal-install
+++ b/install/freeipa-portal-install
@@ -5,11 +5,9 @@ import os
 import shutil
 import sys
 import argparse
-import socket
-import time
 import subprocess
-
-from ipalib import api
+import time
+import pwd
 
 from freeipa_community_portal import PACKAGE_DATA_DIR
 
@@ -19,10 +17,10 @@ HTTPD_CONF = '/etc/httpd/conf.d/freeipa_community_portal.conf'
 VAR_DIR = '/var/lib/freeipa_community_portal'
 WSGI_DIR = '/var/www/wsgi'
 EXECUTABLE = 'freeipa_community_portal.wsgi'
+WEBSERVER_USER = pwd.getpwnam('apache')
 
 
 logger = logging.getLogger()
-
 
 # borrowing a bunch of code from the ipsilon installer
 def openlogs():
@@ -98,14 +96,16 @@ def install(opts):
 
     # create a /var/lib/freeipa-community-portal, if it does not exist
     # this is where our databases live
-    if not os.path.exists(VAR_DIR):
-        os.makedirs(VAR_DIR)
+    if not os.path.isdir(VAR_DIR):
+        os.makedirs(VAR_DIR, mode=0o750)
         # give apache this directory, so apache can write to it.
-        subprocess.call(["chown", "apache:apache", VAR_DIR])
+        os.chown(VAR_DIR, WEBSERVER_USER.pw_uid, WEBSERVER_USER.pw_gid)
 
     # create a key for the captcha
-    with open(os.path.join(VAR_DIR, 'key'), 'w') as fp:
+    with open(os.path.join(VAR_DIR, 'captcha.key'), 'wb') as fp:
         logger.info('writing captcha key file')
+        os.fchmod(fp.fileno(), 0o600)
+        os.fchown(fp.fileno(), WEBSERVER_USER.pw_uid, WEBSERVER_USER.pw_gid)
         fp.write(os.urandom(8))
 
     # set httpd_can_sendmail so that we send mail instead of crashing
@@ -115,7 +115,7 @@ def install(opts):
     # create a directory to store our public scripts.
     if not os.path.exists(WSGI_DIR):
         logger.info('creating directory for WSGI script')
-        os.makedirs(WSGI_DIR)
+        os.makedirs(WSGI_DIR, mode=0o755)
     # remove a file that already exists, if there is one
     if os.path.lexists(os.path.join(WSGI_DIR, EXECUTABLE)):
         logger.warning('executable already exists, overwriting!')


### PR DESCRIPTION
The config option for captcha key_location is now replaced by
db_directory with a fixed file name 'captcha.key' in order to simplify
the configuration even further. The directory and key file are created
on startup if they don't exist yet. That makes deployment and testing
easier, too.

Further more I have tighten security with a couple of modes / chmod and
a secure umask.