### PR TITLE
Don't install freeipa_community_portal_dev.ini as package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,6 @@ recursive-include docs *
 prune docs/build
 
 recursive-include tests *.py
+
+# not installed as package data
+include freeipa_community_portal/conf/freeipa_community_portal_dev.ini

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(name='freeipa_community_portal',
           'freeipa_community_portal': [
               'freeipa_community_portal.wsgi',
               'assets/*/*',
-              'conf/*',
+              'conf/freeipa_community_portal.ini',
+              'conf/httpd.conf',
               'templates/*.html',
               ],
           # TODO: move these somewhere where they can be edited by the user


### PR DESCRIPTION
The freeipa_community_portal_dev.ini is only meant for local testing and
for the unit tests. It should be shipped in the source distribution but
never be installed.