### PR TITLE
Drop separate WSGI entry point

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -49,8 +49,7 @@ Finally, the portal itself::
     pip install git+https://github.com/freeipa/freeipa-community-portal.git
 
 This will automatically unpack a couple of things to the places that we need 
-them. Of note is that it unpacks freeipa_community_portal.wsgi, which unpacks 
-to <python_path>/libexec/, and which is an executable, WSGI-compatible script.
+them.
 
 Before continuing into the installation, the server should be enrolled as a 
 FreeIPA client of the FreeIPA domain it belongs to. Running::
@@ -101,17 +100,6 @@ After this, the installer does::
 which loosens SELinux security so that the portal can send mail. Without this,
 the portal will crash when it attempts to send mail.
 
-Finally, the portal creates a directory, /var/www/wsgi, and symlinks the wsgi
-executable into this directory, so::
-
-    mkdir -P /var/www/wsgi
-    ln -s /usr/libexec/freeipa_community_portal.wsgi \
-          /var/www/wsgi/freeipa_community_portal.wsgi
-
-This is the expected location of the WSGI file according to the provided httpd
-conf file. Is this best practice? I have no idea. Probably not. I'm not very
-good at Apache. If you choose to install it somewhere different, just make sure
-that change is reflected in your Apache configuration file.
 
 Post-installation
 -----------------

--- a/freeipa_community_portal/conf/httpd.conf
+++ b/freeipa_community_portal/conf/httpd.conf
@@ -1,17 +1,30 @@
-# TODO: fix this
-# Alias /assets /usr/share/freeipa_community_portal/assets
+# FreeIPA community portal
+# Apache mod_wsgi configuration
 
-# <Directory /usr/share/freeipa_community_portal/assets>
-#     Order allow,deny
-#     Allow from all
-# </Directory>
+WSGIDaemonProcess communityportal display-name=%{GROUP} \
+    processes=2 threads=15 maximum-requests=5000
+WSGIImportScript /usr/lib/python2.7/site-packages/freeipa_community_portal/wsgi.py \
+    process-group= communityportal application-group= communityportal
+WSGIScriptAlias / /usr/lib/python2.7/site-packages/freeipa_community_portal/wsgi.py
+WSGIScriptReloading Off
+# set WSGIPythonHome if you are using virtual env to deploy the portal
+# WSGIPythonHome /path/to/venv
 
-# figure out where this is
-WSGIScriptAlias / /var/www/wsgi/freeipa_community_portal.wsgi
-
-<Directory /var/www/wsgi>
-    Order allow,deny
+<Location "/">
+    Satisfy Any
+    Order Deny,Allow
     Allow from all
+    WSGIProcessGroup communityportal
+    WSGIApplicationGroup communityportal
+</Location>
 
-    Options FollowSymLinks
+
+Alias /assets /usr/lib/python2.7/site-packages/freeipa_community_portal/assets
+
+<Directory /usr/lib/python2.7/site-packages/freeipa_community_portal/assets>
+    SetHandler None
+    AllowOverride None
+    Satisfy Any
+    Order Deny,Allow
+    Allow from all
 </Directory>

--- a/freeipa_community_portal/wsgi.py
+++ b/freeipa_community_portal/wsgi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import cherrypy
+
 from freeipa_community_portal import app
 from freeipa_community_portal.config import config
 

--- a/install/freeipa-portal-install
+++ b/install/freeipa-portal-install
@@ -15,12 +15,11 @@ LOGFILE = '/var/log/freeipa-portal-install.log'
 PORTAL_CONF = '/etc/freeipa_community_portal.ini'
 HTTPD_CONF = '/etc/httpd/conf.d/freeipa_community_portal.conf'
 VAR_DIR = '/var/lib/freeipa_community_portal'
-WSGI_DIR = '/var/www/wsgi'
-EXECUTABLE = 'freeipa_community_portal.wsgi'
 WEBSERVER_USER = pwd.getpwnam('apache')
 
 
 logger = logging.getLogger()
+
 
 # borrowing a bunch of code from the ipsilon installer
 def openlogs():
@@ -112,20 +111,6 @@ def install(opts):
     logger.info('setting httpd_can_sendmail SELinux bool')
     subprocess.call(['setsebool', '-P',  'httpd_can_sendmail', 'on'])
 
-    # create a directory to store our public scripts.
-    if not os.path.exists(WSGI_DIR):
-        logger.info('creating directory for WSGI script')
-        os.makedirs(WSGI_DIR, mode=0o755)
-    # remove a file that already exists, if there is one
-    if os.path.lexists(os.path.join(WSGI_DIR, EXECUTABLE)):
-        logger.warning('executable already exists, overwriting!')
-        os.remove(os.path.join(WSGI_DIR, EXECUTABLE))
-    # and then symlink the executable from libexec to the public script dir
-    logger.info('symlinking WSGI executable')
-    os.symlink(
-        os.path.join(PACKAGE_DATA_DIR, EXECUTABLE),
-        os.path.join(WSGI_DIR, EXECUTABLE))
-
 
 def uninstall(opts):
     logger.info('Uninstallation started')
@@ -146,12 +131,6 @@ def uninstall(opts):
     logger.info('deleting ' + VAR_DIR)
     if os.path.exists(VAR_DIR):
         shutil.rmtree(VAR_DIR)
-
-    # remove the wsgi script, if it exists.
-    # leave the wsgi directory. idk it feels like something else might use that
-    if os.path.isfile(os.path.join(WSGI_DIR, EXECUTABLE)):
-        logger.info('deleting wsgi symlink')
-        os.remove(os.path.join(WSGI_DIR, EXECUTABLE))
 
 
 def is_uninstall(opts):


### PR DESCRIPTION
There is no need to have a separate and external WSGI entry script. An
ordinary module does suffice, too. It simplifies the installation even
more.