### PR TITLE
Change location of config files and runtime data

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -68,25 +68,25 @@ using this script, you can skip this section and jump to the next thing, which
 outlines some post-install necessities
 
 First, if it is not already present, the installer copies 
-share/freeipa_community_portal/conf/freeipa_community_portal.ini to 
-/etc/freeipa_community_portal.ini. The latter location is where the portal 
-searches for the config, which is mostly used for email settings. If it is not
-present or formatted correctly, the portal will crash on start. Even if you're
-not using the install, I recommend copying this file over, instead of typing
-it from scratch, to avoid errors.
+freeipa_community_portal/conf/freeipa_community_portal.ini to
+/etc/ipa/extensions/community-portal/portal.ini. The latter location is where
+the portal searches for the config, which is mostly used for email settings.
+If it is not present or formatted correctly, the portal will crash on start.
+Even if you're not using the install, I recommend copying this file over,
+instead of typing it from scratch, to avoid errors.
 
 You must edit this configuration file in order for the application to work 
 properly. If the email settings are misconfigured, the application will crash.
 
 Next, the installer copies the apache config from the conf directory to 
-/etc/httpd/conf.d/freeipa_community_portal.conf. If you're doing a custom 
+/etc/httpd/conf.d/ipa-community-portal.conf. If you're doing a custom
 installation of the portal, you probably will not need this file, because you
 probably know what you're doing.
 
 Then, the installer creates the directory where the portal keeps its database::
 
-    mkdir -p -m 750 /var/lib/freeipa_community_portal
-    chown apache:apache /var/lib/freeipa_community_portal/
+    mkdir -p -m 750 /var/lib/ipa-community-portal
+    chown apache:apache /var/lib/ipa-community-portal
 
 If Apache doesn't own this folder, it will vomit when attempting to put 
 database in it. Next, the installer generates a random key and stores it in a
@@ -148,15 +148,14 @@ the portal user. A client keytab for the portal can be acquired with
 ``ipa-getkeytab``. You must properly secure the keytab, so it can only be
 read by the webserver::
 
-    ipa-getkeytab -s IPA_SERVER_HOSTNAME -p portal@YOUR.REALM -k /etc/ipa/portal.keytab
-    chown apache:apache /etc/ipa/portal.keytab
-    chmod 640 /etc/ipa/portal.keytab
+    ipa-getkeytab -s IPA_SERVER_HOSTNAME -p portal@YOUR.REALM -k /etc/ipa/extensions/community-portal/portal.keytab
+    chown apache:apache /etc/ipa/extensions/community-portal/portal.keytab
+    chmod 640 /etc/ipa/extensions/community-portal/portal.keytab
 
 If you don't remember the values for IPA server and realm, have a look at
-``/etc/ipa/default.conf``. You can set the path to keytab in
-``/etc/freeipa_community_portal.ini``. The app sets the environment variable
-``KRB5_CLIENT_KTNAME``, when the value is not empty. ipalib picks the keytab
-up automatically.
+``/etc/ipa/default.conf``. You can set the path to keytab in ``portal.ini``.
+The app sets the environment variable ``KRB5_CLIENT_KTNAME``, when the value
+is not empty. ipalib picks the keytab up automatically.
 
 After all this, you should probably set up and configure mod_ssl and put the 
 app behind HTTPS, but that is outside of the scope of this guide. 

--- a/freeipa_community_portal/conf/freeipa_community_portal.ini
+++ b/freeipa_community_portal/conf/freeipa_community_portal.ini
@@ -1,7 +1,7 @@
 # This file contains canned, production values for deployment. It should be 
 # edited by the end-user for their particular deployment, especially the
 # Mailers section. It is installed as part of the install script to: 
-#     /etc/freeipa_community_portal.ini
+#     /etc/ipa/extensions/community-portal/portal.ini
 
 [Mailers]
 # SMTP connection settings
@@ -22,10 +22,10 @@ default_admin_email=CHANGEME@example.com
 
 [Database]
 # the directory where we store our databases
-db_directory=/var/lib/freeipa_community_portal/
+db_directory=/var/lib/ipa-community-portal/
 
 [KRB5]
 # set KRB5_CLIENT_KTNAME if non-empty
-client_keytab=/etc/ipa/portal.keytab
+client_keytab=/etc/ipa/extensions/community-portal/portal.keytab
 # set KRB5CCNAME if non-empty
 ccache_name=

--- a/freeipa_community_portal/config.py
+++ b/freeipa_community_portal/config.py
@@ -27,7 +27,7 @@ from sqlalchemy import MetaData, create_engine
 class Config(object):
     development_config = ('freeipa_community_portal/conf/'
                           'freeipa_community_portal_dev.ini')
-    deployment_config = '/etc/freeipa_community_portal.ini'
+    deployment_config = '/etc/ipa/extensions/community-portal/portal.ini'
 
     captcha_length = 4
     umask = 0o027

--- a/install/create-portal-user
+++ b/install/create-portal-user
@@ -43,7 +43,7 @@ ROLE = u'Portal management'
 ROLE_DESCRIPTION = u'self-service portals'
 USER = u'portal'
 KEYTAB_OWNER = 'apache'
-KEYTAB = '/etc/ipa/portal.keytab'
+KEYTAB = '/etc/ipa/extensions/community-portal/portal.keytab'
 
 
 def tounicode(s):

--- a/install/freeipa-portal-install
+++ b/install/freeipa-portal-install
@@ -11,10 +11,10 @@ import pwd
 
 from freeipa_community_portal import PACKAGE_DATA_DIR
 
-LOGFILE = '/var/log/freeipa-portal-install.log'
-PORTAL_CONF = '/etc/freeipa_community_portal.ini'
-HTTPD_CONF = '/etc/httpd/conf.d/freeipa_community_portal.conf'
-VAR_DIR = '/var/lib/freeipa_community_portal'
+LOGFILE = '/var/log/ipa-community-portal-install.log'
+PORTAL_CONF = '/etc/ipa/extensions/community-portal/portal.ini'
+HTTPD_CONF = '/etc/httpd/conf.d/ipa-community-portal.conf'
+VAR_DIR = '/var/lib/ipa-community-portal'
 WSGI_DIR = '/var/www/wsgi'
 EXECUTABLE = 'freeipa_community_portal.wsgi'
 WEBSERVER_USER = pwd.getpwnam('apache')
@@ -81,6 +81,9 @@ def install(opts):
 
     # first things first, if the user hasn't supplied a config file, then
     # give them one with sane defaults
+    confdir = os.path.dirname(PORTAL_CONF)
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir, mode=0o755)
     if not os.path.isfile(PORTAL_CONF):
         logger.warning('no portal config, creating one that might not work')
         conf_src = os.path.join(
@@ -94,7 +97,7 @@ def install(opts):
             os.path.join(PACKAGE_DATA_DIR, 'conf', 'httpd.conf'),
             HTTPD_CONF)
 
-    # create a /var/lib/freeipa-community-portal, if it does not exist
+    # create a /var/lib/ipa-community-portal, if it does not exist
     # this is where our databases live
     if not os.path.isdir(VAR_DIR):
         os.makedirs(VAR_DIR, mode=0o750)
@@ -141,7 +144,7 @@ def uninstall(opts):
     if os.path.isfile(HTTPD_CONF):
         os.remove(HTTPD_CONF)
 
-    # delete /var/lib/freeipa-community-portal and everything in it
+    # delete /var/lib/ipa-community-portal and everything in it
     # this is where our databases and key lived
     logger.info('deleting ' + VAR_DIR)
     if os.path.exists(VAR_DIR):


### PR DESCRIPTION
The patch makes the location of config files and runtime data more consistent with the rest of FreeIPA. Alexander has suggested /etc/ipa/extensions as root for all IPA extensions.
